### PR TITLE
Exclude branches on other trees

### DIFF
--- a/internal/utils/stackutils/stackutils.go
+++ b/internal/utils/stackutils/stackutils.go
@@ -244,6 +244,8 @@ func BuildStackTreeForPr(repo *git.Repo, tx meta.WriteTx, branchName string) *St
 	for _, node := range stackTree {
 		for _, child := range node.Children {
 			if containsBranch(child) {
+				// Only include this branch path from the trunk in the stack tree.
+				node.Children = []*StackTreeNode{child}
 				return node
 			}
 		}


### PR DESCRIPTION
If there are other stacks open to trunk, don't include them.

<!-- av pr stack begin -->
# PR Stack
This PR is part of a stack:
* `master`
  * ➡️ **PR https://github.com/oleg-codaio/aviator-av/pull/4**
<!-- av pr stack end -->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
